### PR TITLE
Add password and role fields with hashing

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,8 @@ import { CoursesModule } from './courses/courses.module';
 import { InstitutesModule } from './institutes/institutes.module';
 import { StudentsModule } from './students/students.module';
 import { DesignationsModule } from './designations/designations.module';
+import { RolesModule } from './roles/roles.module';
+import { PartnersModule } from './partners/partners.module';
 
 @Module({
   imports: [
@@ -22,6 +24,8 @@ import { DesignationsModule } from './designations/designations.module';
     InstitutesModule,
     StudentsModule,
     DesignationsModule,
+    RolesModule,
+    PartnersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { ApiTags } from '@nestjs/swagger';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -8,12 +10,12 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('login')
-  login(@Body() body: { email: string; password: string }) {
+  login(@Body() body: LoginDto) {
     return this.authService.login(body.email, body.password);
   }
 
   @Post('register')
-  register(@Body() body: { name: string; email: string; password: string }) {
+  register(@Body() body: RegisterDto) {
     return this.authService.register(body);
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
 import * as bcrypt from 'bcryptjs';
+import { RegisterDto } from './dto/register.dto';
 
 @Injectable()
 export class AuthService {
@@ -27,7 +28,7 @@ export class AuthService {
     };
   }
 
-  async register(dto: { name: string; email: string; password: string }) {
+  async register(dto: RegisterDto) {
     const existing = await this.usersService.findByEmail(dto.email);
     if (existing) throw new UnauthorizedException('Email already in use');
     const user = await this.usersService.create(dto);

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class LoginDto {
+  @ApiProperty()
+  @IsEmail()
+  email: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  password: string;
+}

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,7 +1,7 @@
-import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 
-export class CreateUserDto {
+export class RegisterDto {
   @ApiProperty()
   @IsNotEmpty()
   name: string;

--- a/backend/src/courses/dto/create-course.dto.ts
+++ b/backend/src/courses/dto/create-course.dto.ts
@@ -1,28 +1,131 @@
-import { IsNotEmpty, IsOptional, IsNumber } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsNumber,
+  IsArray,
+  IsBoolean,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Types } from 'mongoose';
 
 export class CreateCourseDto {
+  @ApiProperty()
   @IsNotEmpty()
   title: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   description?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   category?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   level?: string;
 
+  @ApiPropertyOptional({ type: Number })
   @IsOptional()
   @IsNumber()
   price?: number;
 
+  @ApiPropertyOptional()
+  @IsOptional()
+  currency?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  duration?: string;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  enrollments?: number;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  rating?: number;
+
+  @ApiPropertyOptional({ type: Date })
+  @IsOptional()
+  startDate?: Date;
+
+  @ApiPropertyOptional({ type: Date })
+  @IsOptional()
+  endDate?: Date;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  maxStudents?: number;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  tags?: string[];
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  completionRate?: number;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  totalRevenue?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  language?: string;
+
+  @ApiPropertyOptional()
   @IsOptional()
   instructor?: string;
 
+  @ApiPropertyOptional({ type: String })
   @IsOptional()
-  institute?: string;
+  institute?: Types.ObjectId;
 
+  @ApiPropertyOptional()
   @IsOptional()
   status?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  thumbnail?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  videoUrl?: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  requirements?: string[];
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  objectives?: string[];
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  prerequisites?: string[];
+
+  @ApiPropertyOptional({ type: Boolean })
+  @IsOptional()
+  @IsBoolean()
+  certificate?: boolean;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  credits?: number;
+
+  @ApiPropertyOptional({ type: Boolean })
+  @IsOptional()
+  @IsBoolean()
+  featured?: boolean;
 }

--- a/backend/src/courses/schemas/course.schema.ts
+++ b/backend/src/courses/schemas/course.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { Document, Types } from 'mongoose';
 
 @Schema({ timestamps: true })
 export class Course extends Document {
@@ -19,13 +19,70 @@ export class Course extends Document {
   price: number;
 
   @Prop()
-  instructor: string;
+  currency: string;
 
   @Prop()
-  institute: string;
+  duration: string;
+
+  @Prop({ default: 0 })
+  enrollments: number;
+
+  @Prop({ default: 0 })
+  rating: number;
+
+  @Prop()
+  startDate: Date;
+
+  @Prop()
+  endDate: Date;
+
+  @Prop()
+  maxStudents: number;
+
+  @Prop({ type: [String] })
+  tags: string[];
+
+  @Prop()
+  completionRate: number;
+
+  @Prop()
+  totalRevenue: number;
+
+  @Prop()
+  language: string;
+
+  @Prop()
+  instructor: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'Institute' })
+  institute: Types.ObjectId;
 
   @Prop({ default: 'active' })
   status: string;
+
+  @Prop()
+  thumbnail: string;
+
+  @Prop()
+  videoUrl: string;
+
+  @Prop({ type: [String] })
+  requirements: string[];
+
+  @Prop({ type: [String] })
+  objectives: string[];
+
+  @Prop({ type: [String] })
+  prerequisites: string[];
+
+  @Prop({ default: false })
+  certificate: boolean;
+
+  @Prop()
+  credits: number;
+
+  @Prop({ default: false })
+  featured: boolean;
 }
 
 export const CourseSchema = SchemaFactory.createForClass(Course);

--- a/backend/src/designations/dto/create-designation.dto.ts
+++ b/backend/src/designations/dto/create-designation.dto.ts
@@ -1,6 +1,8 @@
 import { IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateDesignationDto {
+  @ApiProperty()
   @IsNotEmpty()
   title: string;
 }

--- a/backend/src/institutes/dto/create-institute.dto.ts
+++ b/backend/src/institutes/dto/create-institute.dto.ts
@@ -1,12 +1,96 @@
-import { IsNotEmpty, IsOptional } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsNumber,
+  MinLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateInstituteDto {
+  @ApiProperty()
   @IsNotEmpty()
   name: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   description?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   logo?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  address?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  phone?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  email?: string;
+
+  @ApiProperty({ minLength: 6 })
+  @MinLength(6)
+  password: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  role?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  website?: string;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  established?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  type?: string;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  rating?: number;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  numberOfStudents?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  city?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  state?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  country?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  tagline?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  facebook?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  twitter?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  instagram?: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  courses?: string[];
 }

--- a/backend/src/institutes/institutes.service.ts
+++ b/backend/src/institutes/institutes.service.ts
@@ -4,6 +4,7 @@ import { Model } from 'mongoose';
 import { CreateInstituteDto } from './dto/create-institute.dto';
 import { UpdateInstituteDto } from './dto/update-institute.dto';
 import { Institute } from './schemas/institute.schema';
+import * as bcrypt from 'bcryptjs';
 
 @Injectable()
 export class InstitutesService {
@@ -11,8 +12,9 @@ export class InstitutesService {
     @InjectModel(Institute.name) private instituteModel: Model<Institute>,
   ) {}
 
-  create(dto: CreateInstituteDto) {
-    const created = new this.instituteModel(dto);
+  async create(dto: CreateInstituteDto) {
+    const hash = await bcrypt.hash(dto.password, 10);
+    const created = new this.instituteModel({ ...dto, password: hash });
     return created.save();
   }
 
@@ -27,6 +29,9 @@ export class InstitutesService {
   }
 
   async update(id: string, dto: UpdateInstituteDto) {
+    if (dto.password) {
+      dto.password = await bcrypt.hash(dto.password, 10);
+    }
     const institute = await this.instituteModel
       .findByIdAndUpdate(id, dto, { new: true })
       .exec();

--- a/backend/src/institutes/schemas/institute.schema.ts
+++ b/backend/src/institutes/schemas/institute.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { Document, Types } from 'mongoose';
 
 @Schema({ timestamps: true })
 export class Institute extends Document {
@@ -11,6 +11,60 @@ export class Institute extends Document {
 
   @Prop()
   logo: string;
+
+  @Prop()
+  address: string;
+
+  @Prop()
+  phone: string;
+
+  @Prop()
+  email: string;
+
+  @Prop({ required: true })
+  password: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'Role' })
+  role: Types.ObjectId;
+
+  @Prop()
+  website: string;
+
+  @Prop()
+  established: number;
+
+  @Prop({ default: 'private' })
+  type: string;
+
+  @Prop({ default: 0 })
+  rating: number;
+
+  @Prop({ default: 0 })
+  numberOfStudents: number;
+
+  @Prop()
+  city: string;
+
+  @Prop()
+  state: string;
+
+  @Prop()
+  country: string;
+
+  @Prop()
+  tagline: string;
+
+  @Prop()
+  facebook: string;
+
+  @Prop()
+  twitter: string;
+
+  @Prop()
+  instagram: string;
+
+  @Prop({ type: [{ type: Types.ObjectId, ref: 'Course' }], default: [] })
+  courses: Types.ObjectId[];
 }
 
 export const InstituteSchema = SchemaFactory.createForClass(Institute);

--- a/backend/src/partners/dto/create-partner.dto.ts
+++ b/backend/src/partners/dto/create-partner.dto.ts
@@ -1,7 +1,7 @@
-import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 
-export class CreateUserDto {
+export class CreatePartnerDto {
   @ApiProperty()
   @IsNotEmpty()
   name: string;
@@ -13,4 +13,7 @@ export class CreateUserDto {
   @ApiProperty({ minLength: 6 })
   @MinLength(6)
   password: string;
+
+  @ApiProperty()
+  role: string;
 }

--- a/backend/src/partners/dto/update-partner.dto.ts
+++ b/backend/src/partners/dto/update-partner.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreatePartnerDto } from './create-partner.dto';
+
+export class UpdatePartnerDto extends PartialType(CreatePartnerDto) {}

--- a/backend/src/partners/partners.controller.ts
+++ b/backend/src/partners/partners.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Post, Body, Param, Put, Delete } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { PartnersService } from './partners.service';
+import { CreatePartnerDto } from './dto/create-partner.dto';
+import { UpdatePartnerDto } from './dto/update-partner.dto';
+
+@ApiTags('partners')
+@Controller('partners')
+export class PartnersController {
+  constructor(private readonly partnersService: PartnersService) {}
+
+  @Post()
+  create(@Body() dto: CreatePartnerDto) {
+    return this.partnersService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.partnersService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.partnersService.findOne(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdatePartnerDto) {
+    return this.partnersService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.partnersService.remove(id);
+  }
+}

--- a/backend/src/partners/partners.module.ts
+++ b/backend/src/partners/partners.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { PartnersService } from './partners.service';
+import { PartnersController } from './partners.controller';
+import { Partner, PartnerSchema } from './schemas/partner.schema';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: Partner.name, schema: PartnerSchema }])],
+  providers: [PartnersService],
+  controllers: [PartnersController],
+})
+export class PartnersModule {}

--- a/backend/src/partners/partners.service.ts
+++ b/backend/src/partners/partners.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { CreatePartnerDto } from './dto/create-partner.dto';
+import { UpdatePartnerDto } from './dto/update-partner.dto';
+import { Partner } from './schemas/partner.schema';
+import * as bcrypt from 'bcryptjs';
+
+@Injectable()
+export class PartnersService {
+  constructor(@InjectModel(Partner.name) private partnerModel: Model<Partner>) {}
+
+  async create(dto: CreatePartnerDto) {
+    const hash = await bcrypt.hash(dto.password, 10);
+    const created = new this.partnerModel({ ...dto, password: hash });
+    return created.save();
+  }
+
+  findAll() {
+    return this.partnerModel.find().exec();
+  }
+
+  async findOne(id: string) {
+    const partner = await this.partnerModel.findById(id).exec();
+    if (!partner) throw new NotFoundException('Partner not found');
+    return partner;
+  }
+
+  async update(id: string, dto: UpdatePartnerDto) {
+    if (dto.password) {
+      dto.password = await bcrypt.hash(dto.password, 10);
+    }
+    const partner = await this.partnerModel
+      .findByIdAndUpdate(id, dto, { new: true })
+      .exec();
+    if (!partner) throw new NotFoundException('Partner not found');
+    return partner;
+  }
+
+  async remove(id: string) {
+    const res = await this.partnerModel.findByIdAndDelete(id).exec();
+    if (!res) throw new NotFoundException('Partner not found');
+  }
+}

--- a/backend/src/partners/schemas/partner.schema.ts
+++ b/backend/src/partners/schemas/partner.schema.ts
@@ -2,7 +2,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
 
 @Schema({ timestamps: true })
-export class Student extends Document {
+export class Partner extends Document {
   @Prop({ required: true })
   name: string;
 
@@ -14,9 +14,6 @@ export class Student extends Document {
 
   @Prop({ type: Types.ObjectId, ref: 'Role' })
   role: Types.ObjectId;
-
-  @Prop({ type: [{ type: Types.ObjectId, ref: 'Course' }], default: [] })
-  courses: Types.ObjectId[];
 }
 
-export const StudentSchema = SchemaFactory.createForClass(Student);
+export const PartnerSchema = SchemaFactory.createForClass(Partner);

--- a/backend/src/roles/roles.module.ts
+++ b/backend/src/roles/roles.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Role, RoleSchema } from './schemas/role.schema';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: Role.name, schema: RoleSchema }])],
+  exports: [MongooseModule],
+})
+export class RolesModule {}

--- a/backend/src/roles/schemas/role.schema.ts
+++ b/backend/src/roles/schemas/role.schema.ts
@@ -1,0 +1,10 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Role extends Document {
+  @Prop({ required: true, unique: true })
+  name: string;
+}
+
+export const RoleSchema = SchemaFactory.createForClass(Role);

--- a/backend/src/students/dto/create-student.dto.ts
+++ b/backend/src/students/dto/create-student.dto.ts
@@ -1,13 +1,31 @@
-import { IsEmail, IsNotEmpty, IsOptional, IsArray } from 'class-validator';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsArray,
+  MinLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Types } from 'mongoose';
 
 export class CreateStudentDto {
+  @ApiProperty()
   @IsNotEmpty()
   name: string;
 
+  @ApiProperty()
   @IsEmail()
   email: string;
 
+  @ApiProperty({ minLength: 6 })
+  @MinLength(6)
+  password: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  role?: string;
+
+  @ApiPropertyOptional({ type: [String] })
   @IsOptional()
   @IsArray()
   courses?: Types.ObjectId[];

--- a/backend/src/students/students.service.ts
+++ b/backend/src/students/students.service.ts
@@ -4,6 +4,7 @@ import { Model } from 'mongoose';
 import { CreateStudentDto } from './dto/create-student.dto';
 import { UpdateStudentDto } from './dto/update-student.dto';
 import { Student } from './schemas/student.schema';
+import * as bcrypt from 'bcryptjs';
 
 @Injectable()
 export class StudentsService {
@@ -11,8 +12,9 @@ export class StudentsService {
     @InjectModel(Student.name) private studentModel: Model<Student>,
   ) {}
 
-  create(dto: CreateStudentDto) {
-    const created = new this.studentModel(dto);
+  async create(dto: CreateStudentDto) {
+    const hash = await bcrypt.hash(dto.password, 10);
+    const created = new this.studentModel({ ...dto, password: hash });
     return created.save();
   }
 
@@ -27,6 +29,9 @@ export class StudentsService {
   }
 
   async update(id: string, dto: UpdateStudentDto) {
+    if (dto.password) {
+      dto.password = await bcrypt.hash(dto.password, 10);
+    }
     const student = await this.studentModel
       .findByIdAndUpdate(id, dto, { new: true })
       .exec();


### PR DESCRIPTION
## Summary
- introduce Role schema and module
- add Partner module with hashed passwords
- expand Student and Institute DTOs with password and role
- reference roles in Student and Institute schemas
- hash passwords when creating or updating students, institutes, and partners

## Testing
- `npm --prefix backend test` *(fails: Nest can't resolve dependencies)*
- `npm run lint` *(fails: next CLI not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888768a25348323b74e31657ec8c759