### PR TITLE
Add separate staff and role modules for partners and institutes

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,11 @@ import { RoleModule } from './role/role.module';
 import { StudentSchema } from './students/schemas/student.schema';
 import { RoleSchema } from './role/schemas/role.schema';
 import { MailerModule } from './mailer/mailer.module';
+import { StaffModule } from './staff/staff.module';
+import { InstituteRoleModule } from './institute_role/institute_role.module';
+import { PartnerRoleModule } from './partner_role/partner_role.module';
+import { InstituteStaffModule } from './institute_staff/institute_staff.module';
+import { PartnerStaffModule } from './partner_staff/partner_staff.module';
 
 @Module({
   imports: [
@@ -33,6 +38,11 @@ import { MailerModule } from './mailer/mailer.module';
     DesignationsModule,
     RoleModule,
     PartnersModule,
+    StaffModule,
+    InstituteRoleModule,
+    PartnerRoleModule,
+    InstituteStaffModule,
+    PartnerStaffModule,
     MailerModule,
   ],
   controllers: [AppController],

--- a/backend/src/helper/model_names.ts
+++ b/backend/src/helper/model_names.ts
@@ -9,4 +9,11 @@ export enum ModelNames {
   COURSES = 'courses',
   COURSE_OPTIONS = 'courseoptions',
   DESIGNATIONS = 'designations',
+  STAFFS = 'staffs',
+  INSTITUTE_ROLES = 'institute_roles',
+  INSTITUTE_ROLE_OPTIONS = 'institute_role_options',
+  INSTITUTE_STAFFS = 'institute_staffs',
+  PARTNER_ROLES = 'partner_roles',
+  PARTNER_ROLE_OPTIONS = 'partner_role_options',
+  PARTNER_STAFFS = 'partner_staffs',
 }

--- a/backend/src/institute_role/institute_role.controller.ts
+++ b/backend/src/institute_role/institute_role.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Body, Param, Delete, Patch } from '@nestjs/common';
+import { InstituteRoleService } from './institute_role.service';
+import { RoleDto } from 'src/role/dto/role.dto';
+
+@Controller('institute-role')
+export class InstituteRoleController {
+  constructor(private readonly service: InstituteRoleService) {}
+
+  @Post()
+  create(@Body() dto: RoleDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: RoleDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/backend/src/institute_role/institute_role.module.ts
+++ b/backend/src/institute_role/institute_role.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { InstituteRoleService } from './institute_role.service';
+import { InstituteRoleController } from './institute_role.controller';
+import { InstituteRoleSchema } from './schemas/institute_role.schema';
+import { InstituteRoleOptionsSchema } from './schemas/institute_role_options.schema';
+import { InstituteRoleOptionService } from './institute_role_option.service';
+import { InstituteRoleOptionController } from './institute_role_option.controller';
+import { ModelNames } from 'src/helper/model_names';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: ModelNames.INSTITUTE_ROLES, schema: InstituteRoleSchema },
+      { name: ModelNames.INSTITUTE_ROLE_OPTIONS, schema: InstituteRoleOptionsSchema },
+    ]),
+  ],
+  controllers: [InstituteRoleController, InstituteRoleOptionController],
+  providers: [InstituteRoleService, InstituteRoleOptionService],
+  exports: [InstituteRoleService],
+})
+export class InstituteRoleModule {}

--- a/backend/src/institute_role/institute_role.service.ts
+++ b/backend/src/institute_role/institute_role.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { RoleDto } from 'src/role/dto/role.dto';
+import { ModelNames } from 'src/helper/model_names';
+import { InstituteRole } from './schemas/institute_role.schema';
+
+@Injectable()
+export class InstituteRoleService {
+  constructor(
+    @InjectModel(ModelNames.INSTITUTE_ROLES)
+    private roleModel: Model<InstituteRole>,
+  ) {}
+
+  async create(dto: RoleDto) {
+    const result = await this.roleModel.create(dto);
+    return result;
+  }
+
+  async findAll() {
+    const result = await this.roleModel.find().populate('options');
+    return result;
+  }
+
+  async findOne(id: string) {
+    return this.roleModel.findById(id).populate('options').exec();
+  }
+
+  async update(id: string, dto: RoleDto) {
+    return this.roleModel.findByIdAndUpdate(id, dto, {
+      new: true,
+      runValidators: true,
+    });
+  }
+
+  async remove(id: string) {
+    return this.roleModel.findByIdAndDelete(id).exec();
+  }
+}

--- a/backend/src/institute_role/institute_role_option.controller.ts
+++ b/backend/src/institute_role/institute_role_option.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Body, Param, Delete, Patch } from '@nestjs/common';
+import { InstituteRoleOptionService } from './institute_role_option.service';
+import { RoleOptionsDto } from 'src/role/dto/role_options.dto';
+
+@Controller('institute-role-option')
+export class InstituteRoleOptionController {
+  constructor(private readonly service: InstituteRoleOptionService) {}
+
+  @Post()
+  create(@Body() dto: RoleOptionsDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: RoleOptionsDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/backend/src/institute_role/institute_role_option.service.ts
+++ b/backend/src/institute_role/institute_role_option.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { RoleOptionsDto } from 'src/role/dto/role_options.dto';
+import { ModelNames } from 'src/helper/model_names';
+import { InstituteRoleOptions } from './schemas/institute_role_options.schema';
+
+@Injectable()
+export class InstituteRoleOptionService {
+  constructor(
+    @InjectModel(ModelNames.INSTITUTE_ROLE_OPTIONS)
+    private optionModel: Model<InstituteRoleOptions>,
+  ) {}
+
+  create(dto: RoleOptionsDto) {
+    const created = new this.optionModel(dto);
+    return created.save();
+  }
+
+  async findAll() {
+    return this.optionModel.find().exec();
+  }
+
+  async findOne(id: string) {
+    return this.optionModel.findById(id).exec();
+  }
+
+  async update(id: string, dto: RoleOptionsDto) {
+    return this.optionModel.findByIdAndUpdate(id, dto, {
+      new: true,
+      runValidators: true,
+    });
+  }
+
+  async remove(id: string) {
+    return this.optionModel.findByIdAndDelete(id).exec();
+  }
+}

--- a/backend/src/institute_role/schemas/institute_role.schema.ts
+++ b/backend/src/institute_role/schemas/institute_role.schema.ts
@@ -1,0 +1,23 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { Document } from 'mongoose';
+import { ModelNames } from 'src/helper/model_names';
+const slug = require('mongoose-slug-generator');
+
+mongoose.plugin(slug);
+@Schema({ timestamps: true, collection: ModelNames.INSTITUTE_ROLES })
+export class InstituteRole extends Document {
+  @Prop({ required: true, unique: true, trim: true, lowercase: true })
+  name: string;
+
+  @Prop({ type: String, slug: 'name' })
+  value: string;
+
+  @Prop({
+    type: [mongoose.Schema.Types.ObjectId],
+    ref: 'institute_role_options',
+    default: [],
+  })
+  options: mongoose.Schema.Types.ObjectId[];
+}
+
+export const InstituteRoleSchema = SchemaFactory.createForClass(InstituteRole);

--- a/backend/src/institute_role/schemas/institute_role_options.schema.ts
+++ b/backend/src/institute_role/schemas/institute_role_options.schema.ts
@@ -1,0 +1,16 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { Document } from 'mongoose';
+import { ModelNames } from 'src/helper/model_names';
+const slug = require('mongoose-slug-generator');
+
+mongoose.plugin(slug);
+@Schema({ timestamps: true, collection: ModelNames.INSTITUTE_ROLE_OPTIONS })
+export class InstituteRoleOptions extends Document {
+  @Prop({ required: true, unique: true, trim: true, lowercase: true })
+  name: string;
+
+  @Prop({ type: String, slug: 'name' })
+  value: string;
+}
+
+export const InstituteRoleOptionsSchema = SchemaFactory.createForClass(InstituteRoleOptions);

--- a/backend/src/institute_staff/institute_staff.controller.ts
+++ b/backend/src/institute_staff/institute_staff.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Post, Body, Param, Delete, Put } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { InstituteStaffService } from './institute_staff.service';
+import { CreateStaffDto } from 'src/staff/dto/create-staff.dto';
+import { UpdateStaffDto } from 'src/staff/dto/update-staff.dto';
+
+@ApiTags('institute-staff')
+@Controller('institute-staff')
+export class InstituteStaffController {
+  constructor(private readonly staffService: InstituteStaffService) {}
+
+  @Post()
+  create(@Body() dto: CreateStaffDto) {
+    return this.staffService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.staffService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.staffService.findOne(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateStaffDto) {
+    return this.staffService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.staffService.remove(id);
+  }
+}

--- a/backend/src/institute_staff/institute_staff.module.ts
+++ b/backend/src/institute_staff/institute_staff.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { InstituteStaffService } from './institute_staff.service';
+import { InstituteStaffController } from './institute_staff.controller';
+import { InstituteStaffSchema } from './schemas/institute_staff.schema';
+import { ModelNames } from 'src/helper/model_names';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: ModelNames.INSTITUTE_STAFFS, schema: InstituteStaffSchema },
+    ]),
+  ],
+  providers: [InstituteStaffService],
+  controllers: [InstituteStaffController],
+  exports: [InstituteStaffService],
+})
+export class InstituteStaffModule {}

--- a/backend/src/institute_staff/institute_staff.service.ts
+++ b/backend/src/institute_staff/institute_staff.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { CreateStaffDto } from 'src/staff/dto/create-staff.dto';
+import { UpdateStaffDto } from 'src/staff/dto/update-staff.dto';
+import { ModelNames } from 'src/helper/model_names';
+import { InstituteStaff } from './schemas/institute_staff.schema';
+import * as bcrypt from 'bcryptjs';
+
+@Injectable()
+export class InstituteStaffService {
+  constructor(
+    @InjectModel(ModelNames.INSTITUTE_STAFFS)
+    private staffModel: Model<InstituteStaff>,
+  ) {}
+
+  async create(dto: CreateStaffDto) {
+    const hash = await bcrypt.hash(dto.password ?? '', 10);
+    const created = new this.staffModel({ ...dto, password: hash });
+    return created.save();
+  }
+
+  async findAll() {
+    return this.staffModel
+      .find()
+      .populate('role')
+      .populate('institute')
+      .exec();
+  }
+
+  async findOne(id: string) {
+    const staff = await this.staffModel
+      .findById(id)
+      .populate('role')
+      .populate('institute')
+      .exec();
+    if (!staff) throw new NotFoundException('Staff not found');
+    return staff;
+  }
+
+  async update(id: string, dto: UpdateStaffDto) {
+    if (dto.password) {
+      dto.password = await bcrypt.hash(dto.password, 10);
+    }
+    const staff = await this.staffModel
+      .findByIdAndUpdate(id, dto, { new: true })
+      .exec();
+    if (!staff) throw new NotFoundException('Staff not found');
+    return staff;
+  }
+
+  async remove(id: string) {
+    const res = await this.staffModel.findByIdAndDelete(id).exec();
+    if (!res) throw new NotFoundException('Staff not found');
+  }
+}

--- a/backend/src/institute_staff/schemas/institute_staff.schema.ts
+++ b/backend/src/institute_staff/schemas/institute_staff.schema.ts
@@ -1,0 +1,23 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { Document } from 'mongoose';
+import { ModelNames } from 'src/helper/model_names';
+
+@Schema({ timestamps: true, collection: ModelNames.INSTITUTE_STAFFS })
+export class InstituteStaff extends Document {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true, unique: true })
+  email: string;
+
+  @Prop({ required: true })
+  password: string;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'institute_roles' })
+  role: mongoose.Schema.Types.ObjectId;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'institutes' })
+  institute: mongoose.Schema.Types.ObjectId;
+}
+
+export const InstituteStaffSchema = SchemaFactory.createForClass(InstituteStaff);

--- a/backend/src/partner_role/partner_role.controller.ts
+++ b/backend/src/partner_role/partner_role.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Body, Param, Delete, Patch } from '@nestjs/common';
+import { PartnerRoleService } from './partner_role.service';
+import { RoleDto } from 'src/role/dto/role.dto';
+
+@Controller('partner-role')
+export class PartnerRoleController {
+  constructor(private readonly service: PartnerRoleService) {}
+
+  @Post()
+  create(@Body() dto: RoleDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: RoleDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/backend/src/partner_role/partner_role.module.ts
+++ b/backend/src/partner_role/partner_role.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { PartnerRoleService } from './partner_role.service';
+import { PartnerRoleController } from './partner_role.controller';
+import { PartnerRoleSchema } from './schemas/partner_role.schema';
+import { PartnerRoleOptionsSchema } from './schemas/partner_role_options.schema';
+import { PartnerRoleOptionService } from './partner_role_option.service';
+import { PartnerRoleOptionController } from './partner_role_option.controller';
+import { ModelNames } from 'src/helper/model_names';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: ModelNames.PARTNER_ROLES, schema: PartnerRoleSchema },
+      { name: ModelNames.PARTNER_ROLE_OPTIONS, schema: PartnerRoleOptionsSchema },
+    ]),
+  ],
+  controllers: [PartnerRoleController, PartnerRoleOptionController],
+  providers: [PartnerRoleService, PartnerRoleOptionService],
+  exports: [PartnerRoleService],
+})
+export class PartnerRoleModule {}

--- a/backend/src/partner_role/partner_role.service.ts
+++ b/backend/src/partner_role/partner_role.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { RoleDto } from 'src/role/dto/role.dto';
+import { ModelNames } from 'src/helper/model_names';
+import { PartnerRole } from './schemas/partner_role.schema';
+
+@Injectable()
+export class PartnerRoleService {
+  constructor(
+    @InjectModel(ModelNames.PARTNER_ROLES)
+    private roleModel: Model<PartnerRole>,
+  ) {}
+
+  async create(dto: RoleDto) {
+    return this.roleModel.create(dto);
+  }
+
+  async findAll() {
+    return this.roleModel.find().populate('options');
+  }
+
+  async findOne(id: string) {
+    return this.roleModel.findById(id).populate('options').exec();
+  }
+
+  async update(id: string, dto: RoleDto) {
+    return this.roleModel.findByIdAndUpdate(id, dto, {
+      new: true,
+      runValidators: true,
+    });
+  }
+
+  async remove(id: string) {
+    return this.roleModel.findByIdAndDelete(id).exec();
+  }
+}

--- a/backend/src/partner_role/partner_role_option.controller.ts
+++ b/backend/src/partner_role/partner_role_option.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Body, Param, Delete, Patch } from '@nestjs/common';
+import { PartnerRoleOptionService } from './partner_role_option.service';
+import { RoleOptionsDto } from 'src/role/dto/role_options.dto';
+
+@Controller('partner-role-option')
+export class PartnerRoleOptionController {
+  constructor(private readonly service: PartnerRoleOptionService) {}
+
+  @Post()
+  create(@Body() dto: RoleOptionsDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: RoleOptionsDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/backend/src/partner_role/partner_role_option.service.ts
+++ b/backend/src/partner_role/partner_role_option.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { RoleOptionsDto } from 'src/role/dto/role_options.dto';
+import { ModelNames } from 'src/helper/model_names';
+import { PartnerRoleOptions } from './schemas/partner_role_options.schema';
+
+@Injectable()
+export class PartnerRoleOptionService {
+  constructor(
+    @InjectModel(ModelNames.PARTNER_ROLE_OPTIONS)
+    private optionModel: Model<PartnerRoleOptions>,
+  ) {}
+
+  create(dto: RoleOptionsDto) {
+    const created = new this.optionModel(dto);
+    return created.save();
+  }
+
+  async findAll() {
+    return this.optionModel.find().exec();
+  }
+
+  async findOne(id: string) {
+    return this.optionModel.findById(id).exec();
+  }
+
+  async update(id: string, dto: RoleOptionsDto) {
+    return this.optionModel.findByIdAndUpdate(id, dto, {
+      new: true,
+      runValidators: true,
+    });
+  }
+
+  async remove(id: string) {
+    return this.optionModel.findByIdAndDelete(id).exec();
+  }
+}

--- a/backend/src/partner_role/schemas/partner_role.schema.ts
+++ b/backend/src/partner_role/schemas/partner_role.schema.ts
@@ -1,0 +1,23 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { Document } from 'mongoose';
+import { ModelNames } from 'src/helper/model_names';
+const slug = require('mongoose-slug-generator');
+
+mongoose.plugin(slug);
+@Schema({ timestamps: true, collection: ModelNames.PARTNER_ROLES })
+export class PartnerRole extends Document {
+  @Prop({ required: true, unique: true, trim: true, lowercase: true })
+  name: string;
+
+  @Prop({ type: String, slug: 'name' })
+  value: string;
+
+  @Prop({
+    type: [mongoose.Schema.Types.ObjectId],
+    ref: 'partner_role_options',
+    default: [],
+  })
+  options: mongoose.Schema.Types.ObjectId[];
+}
+
+export const PartnerRoleSchema = SchemaFactory.createForClass(PartnerRole);

--- a/backend/src/partner_role/schemas/partner_role_options.schema.ts
+++ b/backend/src/partner_role/schemas/partner_role_options.schema.ts
@@ -1,0 +1,16 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { Document } from 'mongoose';
+import { ModelNames } from 'src/helper/model_names';
+const slug = require('mongoose-slug-generator');
+
+mongoose.plugin(slug);
+@Schema({ timestamps: true, collection: ModelNames.PARTNER_ROLE_OPTIONS })
+export class PartnerRoleOptions extends Document {
+  @Prop({ required: true, unique: true, trim: true, lowercase: true })
+  name: string;
+
+  @Prop({ type: String, slug: 'name' })
+  value: string;
+}
+
+export const PartnerRoleOptionsSchema = SchemaFactory.createForClass(PartnerRoleOptions);

--- a/backend/src/partner_staff/partner_staff.controller.ts
+++ b/backend/src/partner_staff/partner_staff.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Post, Body, Param, Delete, Put } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { PartnerStaffService } from './partner_staff.service';
+import { CreateStaffDto } from 'src/staff/dto/create-staff.dto';
+import { UpdateStaffDto } from 'src/staff/dto/update-staff.dto';
+
+@ApiTags('partner-staff')
+@Controller('partner-staff')
+export class PartnerStaffController {
+  constructor(private readonly staffService: PartnerStaffService) {}
+
+  @Post()
+  create(@Body() dto: CreateStaffDto) {
+    return this.staffService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.staffService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.staffService.findOne(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateStaffDto) {
+    return this.staffService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.staffService.remove(id);
+  }
+}

--- a/backend/src/partner_staff/partner_staff.module.ts
+++ b/backend/src/partner_staff/partner_staff.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { PartnerStaffService } from './partner_staff.service';
+import { PartnerStaffController } from './partner_staff.controller';
+import { PartnerStaffSchema } from './schemas/partner_staff.schema';
+import { ModelNames } from 'src/helper/model_names';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: ModelNames.PARTNER_STAFFS, schema: PartnerStaffSchema },
+    ]),
+  ],
+  providers: [PartnerStaffService],
+  controllers: [PartnerStaffController],
+  exports: [PartnerStaffService],
+})
+export class PartnerStaffModule {}

--- a/backend/src/partner_staff/partner_staff.service.ts
+++ b/backend/src/partner_staff/partner_staff.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { CreateStaffDto } from 'src/staff/dto/create-staff.dto';
+import { UpdateStaffDto } from 'src/staff/dto/update-staff.dto';
+import { ModelNames } from 'src/helper/model_names';
+import { PartnerStaff } from './schemas/partner_staff.schema';
+import * as bcrypt from 'bcryptjs';
+
+@Injectable()
+export class PartnerStaffService {
+  constructor(
+    @InjectModel(ModelNames.PARTNER_STAFFS)
+    private staffModel: Model<PartnerStaff>,
+  ) {}
+
+  async create(dto: CreateStaffDto) {
+    const hash = await bcrypt.hash(dto.password ?? '', 10);
+    const created = new this.staffModel({ ...dto, password: hash });
+    return created.save();
+  }
+
+  async findAll() {
+    return this.staffModel
+      .find()
+      .populate('role')
+      .populate('partner')
+      .exec();
+  }
+
+  async findOne(id: string) {
+    const staff = await this.staffModel
+      .findById(id)
+      .populate('role')
+      .populate('partner')
+      .exec();
+    if (!staff) throw new NotFoundException('Staff not found');
+    return staff;
+  }
+
+  async update(id: string, dto: UpdateStaffDto) {
+    if (dto.password) {
+      dto.password = await bcrypt.hash(dto.password, 10);
+    }
+    const staff = await this.staffModel
+      .findByIdAndUpdate(id, dto, { new: true })
+      .exec();
+    if (!staff) throw new NotFoundException('Staff not found');
+    return staff;
+  }
+
+  async remove(id: string) {
+    const res = await this.staffModel.findByIdAndDelete(id).exec();
+    if (!res) throw new NotFoundException('Staff not found');
+  }
+}

--- a/backend/src/partner_staff/schemas/partner_staff.schema.ts
+++ b/backend/src/partner_staff/schemas/partner_staff.schema.ts
@@ -1,0 +1,23 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { Document } from 'mongoose';
+import { ModelNames } from 'src/helper/model_names';
+
+@Schema({ timestamps: true, collection: ModelNames.PARTNER_STAFFS })
+export class PartnerStaff extends Document {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true, unique: true })
+  email: string;
+
+  @Prop({ required: true })
+  password: string;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'partner_roles' })
+  role: mongoose.Schema.Types.ObjectId;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'partners' })
+  partner: mongoose.Schema.Types.ObjectId;
+}
+
+export const PartnerStaffSchema = SchemaFactory.createForClass(PartnerStaff);

--- a/backend/src/role/role.service.ts
+++ b/backend/src/role/role.service.ts
@@ -25,8 +25,9 @@ export class RoleService {
     return result;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} role`;
+  async findOne(id: string) {
+    const role = await this.roleModel.findById(id).populate('options').exec();
+    return role;
   }
 
   async update(id: string, updateRoleDto: RoleDto) {
@@ -41,7 +42,7 @@ export class RoleService {
     return result;
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} role`;
+  async remove(id: string) {
+    return this.roleModel.findByIdAndDelete(id).exec();
   }
 }

--- a/backend/src/role/role_option.service.ts
+++ b/backend/src/role/role_option.service.ts
@@ -22,15 +22,20 @@ export class RoleOptionService {
     return result;
   }
 
-  findOne(id: string) {
-    return `This action returns a #${id} role`;
+  async findOne(id: string) {
+    const option = await this.roleOptionModel.findById(id).exec();
+    return option;
   }
 
-  update(id: string, updateRoleDto: RoleOptionsDto) {
-    return `This action updates a #${id} role`;
+  async update(id: string, updateRoleDto: RoleOptionsDto) {
+    const res = await this.roleOptionModel.findByIdAndUpdate(id, updateRoleDto, {
+      new: true,
+      runValidators: true,
+    });
+    return res;
   }
 
-  remove(id: string) {
-    return `This action removes a #${id} role`;
+  async remove(id: string) {
+    return this.roleOptionModel.findByIdAndDelete(id).exec();
   }
 }

--- a/backend/src/staff/dto/create-staff.dto.ts
+++ b/backend/src/staff/dto/create-staff.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, MinLength, IsOptional } from 'class-validator';
+
+export class CreateStaffDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty()
+  @IsEmail()
+  email: string;
+
+  @ApiPropertyOptional({ minLength: 6 })
+  @IsOptional()
+  @MinLength(6)
+  password?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  role?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  institute?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  partner?: string;
+}

--- a/backend/src/staff/dto/update-staff.dto.ts
+++ b/backend/src/staff/dto/update-staff.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateStaffDto } from './create-staff.dto';
+
+export class UpdateStaffDto extends PartialType(CreateStaffDto) {}

--- a/backend/src/staff/schemas/staff.schema.ts
+++ b/backend/src/staff/schemas/staff.schema.ts
@@ -1,0 +1,26 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { Document } from 'mongoose';
+import { ModelNames } from 'src/helper/model_names';
+
+@Schema({ timestamps: true, collection: ModelNames.STAFFS })
+export class Staff extends Document {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true, unique: true })
+  email: string;
+
+  @Prop({ required: true })
+  password: string;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'roles' })
+  role: mongoose.Schema.Types.ObjectId;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'institutes' })
+  institute: mongoose.Schema.Types.ObjectId;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'partners' })
+  partner: mongoose.Schema.Types.ObjectId;
+}
+
+export const StaffSchema = SchemaFactory.createForClass(Staff);

--- a/backend/src/staff/staff.controller.ts
+++ b/backend/src/staff/staff.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Post, Body, Param, Delete, Put } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { StaffService } from './staff.service';
+import { CreateStaffDto } from './dto/create-staff.dto';
+import { UpdateStaffDto } from './dto/update-staff.dto';
+
+@ApiTags('staff')
+@Controller('staff')
+export class StaffController {
+  constructor(private readonly staffService: StaffService) {}
+
+  @Post()
+  create(@Body() dto: CreateStaffDto) {
+    return this.staffService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.staffService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.staffService.findOne(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateStaffDto) {
+    return this.staffService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.staffService.remove(id);
+  }
+}

--- a/backend/src/staff/staff.module.ts
+++ b/backend/src/staff/staff.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { StaffService } from './staff.service';
+import { StaffController } from './staff.controller';
+import { StaffSchema } from './schemas/staff.schema';
+import { ModelNames } from 'src/helper/model_names';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: ModelNames.STAFFS, schema: StaffSchema },
+    ]),
+  ],
+  providers: [StaffService],
+  controllers: [StaffController],
+  exports: [StaffService],
+})
+export class StaffModule {}

--- a/backend/src/staff/staff.service.ts
+++ b/backend/src/staff/staff.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { ModelNames } from 'src/helper/model_names';
+import { CreateStaffDto } from './dto/create-staff.dto';
+import { UpdateStaffDto } from './dto/update-staff.dto';
+import { Staff } from './schemas/staff.schema';
+import * as bcrypt from 'bcryptjs';
+
+@Injectable()
+export class StaffService {
+  constructor(
+    @InjectModel(ModelNames.STAFFS) private staffModel: Model<Staff>,
+  ) {}
+
+  async create(dto: CreateStaffDto) {
+    const hash = await bcrypt.hash(dto.password ?? '', 10);
+    const created = new this.staffModel({ ...dto, password: hash });
+    return created.save();
+  }
+
+  async findAll() {
+    return this.staffModel
+      .find()
+      .populate('role')
+      .populate('institute')
+      .populate('partner')
+      .exec();
+  }
+
+  async findOne(id: string) {
+    const staff = await this.staffModel
+      .findById(id)
+      .populate('role')
+      .populate('institute')
+      .populate('partner')
+      .exec();
+    if (!staff) throw new NotFoundException('Staff not found');
+    return staff;
+  }
+
+  async update(id: string, dto: UpdateStaffDto) {
+    if (dto.password) {
+      dto.password = await bcrypt.hash(dto.password, 10);
+    }
+    const staff = await this.staffModel
+      .findByIdAndUpdate(id, dto, { new: true })
+      .exec();
+    if (!staff) throw new NotFoundException('Staff not found');
+    return staff;
+  }
+
+  async remove(id: string) {
+    const res = await this.staffModel.findByIdAndDelete(id).exec();
+    if (!res) throw new NotFoundException('Staff not found');
+  }
+}


### PR DESCRIPTION
## Summary
- expand `ModelNames` with collections for institute/partner staff and roles
- register new staff and role modules in `AppModule`
- implement CRUD modules for InstituteStaff, PartnerStaff, InstituteRole, and PartnerRole

## Testing
- `npm install`
- `npm test` *(fails: cannot find module 'src/helper/model_names')*

------
https://chatgpt.com/codex/tasks/task_e_688b3264c2708323bef2a27a50475fa6