### PR TITLE
Expand institute schema

### DIFF
--- a/backend/src/institutes/dto/create-institute.dto.ts
+++ b/backend/src/institutes/dto/create-institute.dto.ts
@@ -1,10 +1,4 @@
-
-import {
-  IsNotEmpty,
-  IsOptional,
-  IsNumber,
-  MinLength,
-} from 'class-validator';
+import { IsNotEmpty, IsOptional, IsNumber, MinLength } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
@@ -27,17 +21,40 @@ export class CreateInstituteDto {
 
   @ApiPropertyOptional()
   @IsOptional()
+  zipCode?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
   phone?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  alternatePhone?: string;
 
   @ApiPropertyOptional()
   @IsOptional()
   email?: string;
 
-
   @ApiPropertyOptional({ minLength: 6 })
   @IsOptional()
   @MinLength(6)
   password?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  contactPerson?: string;
+
+  @ApiPropertyOptional({ default: 'pending' })
+  @IsOptional()
+  status?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  approvedBy?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  approvedAt?: Date;
 
   @ApiPropertyOptional()
   @IsOptional()
@@ -64,7 +81,17 @@ export class CreateInstituteDto {
   @ApiPropertyOptional({ type: Number })
   @IsOptional()
   @IsNumber()
-  numberOfStudents?: number;
+  totalStudents?: number;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  studentCapacity?: number;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  facultyCount?: number;
 
   @ApiPropertyOptional()
   @IsOptional()
@@ -81,6 +108,24 @@ export class CreateInstituteDto {
   @ApiPropertyOptional()
   @IsOptional()
   tagline?: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  accreditation?: string[];
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  specialization?: string[];
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  totalCourses?: number;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  totalEducators?: number;
 
   @ApiPropertyOptional()
   @IsOptional()

--- a/backend/src/institutes/schemas/institute.schema.ts
+++ b/backend/src/institutes/schemas/institute.schema.ts
@@ -17,13 +17,31 @@ export class Institute extends Document {
   address: string;
 
   @Prop()
+  zipCode: string;
+
+  @Prop()
   phone: string;
+
+  @Prop()
+  alternatePhone: string;
 
   @Prop()
   email: string;
 
   @Prop({ required: true })
   password: string;
+
+  @Prop()
+  contactPerson: string;
+
+  @Prop({ default: 'pending' })
+  status: string;
+
+  @Prop()
+  approvedBy: string;
+
+  @Prop()
+  approvedAt: Date;
 
   @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Role' })
   role: mongoose.Schema.Types.ObjectId;
@@ -41,7 +59,13 @@ export class Institute extends Document {
   rating: number;
 
   @Prop({ default: 0 })
-  numberOfStudents: number;
+  totalStudents: number;
+
+  @Prop({ type: Number })
+  studentCapacity: number;
+
+  @Prop({ type: Number })
+  facultyCount: number;
 
   @Prop()
   city: string;
@@ -54,6 +78,18 @@ export class Institute extends Document {
 
   @Prop()
   tagline: string;
+
+  @Prop({ type: [String], default: [] })
+  accreditation: string[];
+
+  @Prop({ type: [String], default: [] })
+  specialization: string[];
+
+  @Prop({ type: Number, default: 0 })
+  totalCourses: number;
+
+  @Prop({ type: Number, default: 0 })
+  totalEducators: number;
 
   @Prop()
   facebook: string;


### PR DESCRIPTION
## Summary
- expand `Institute` schema to include fields used in the frontend
- update `CreateInstituteDto` accordingly

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm test` *(fails: cannot find module 'src/helper/model_names')*

------
https://chatgpt.com/codex/tasks/task_e_688c856a1ff48323956506aa8c14c79f